### PR TITLE
Add include mode for split tunneling

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ A single process registry instance is shared between most parts of the driver.
 
 The registered image data structure is used to maintain a set of device paths.
 
-A single instance identifies all executable images that should be excluded from the tunnel. Said instance is shared between IOCTL handlers and the process management subsystem.
+A single instance identifies all executable images that should either be
+excluded from or explicitly included in the tunnel, depending on the configured
+mode. Said instance is shared between IOCTL handlers and the process management
+subsystem.
 
 ## Driver states
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ It will only build on Windows 10, version 2004 or later.
 
 The features mentioned above are wholly implemented in the driver. However, the driver needs a user mode agent to initially and continuously provide it with configuration data.
 
-Specifically, the agent provides a set of application paths that should be excluded from the tunnel. It also communicates the tunnel IPs (IPv4/IPv6) as well as IPs of the primary network interface.
+Specifically, the agent provides a set of application paths and indicates whether
+the list represents processes to exclude from the tunnel or ones that should
+remain inside the tunnel. It also communicates the tunnel IPs (IPv4/IPv6) as well as IPs of the primary network interface.
 
 The agent is required to monitor network interfaces and update the driver with new IPs, as they change.
 

--- a/src/containers.h
+++ b/src/containers.h
@@ -4,6 +4,7 @@
 #include <wdf.h>
 #include "containers/procregistry.h"
 #include "containers/registeredimage.h"
+#include "defs/config.h"
 
 //
 // The single instance of this struct lives in the device context.
@@ -24,5 +25,6 @@ struct PROCESS_REGISTRY_MGMT
 //
 struct REGISTERED_IMAGE_MGMT
 {
-	registeredimage::CONTEXT * volatile Instance;
+        registeredimage::CONTEXT * volatile Instance;
+        ST_SPLIT_LIST_MODE Mode;
 };

--- a/src/defs/config.h
+++ b/src/defs/config.h
@@ -4,6 +4,15 @@
 // Structures related to configuration.
 //
 
+typedef enum tag_ST_SPLIT_LIST_MODE
+{
+        // List contains apps that should be excluded from the tunnel
+        ST_SPLIT_LIST_EXCLUDE = 0,
+
+        // List contains apps that should remain inside the tunnel
+        ST_SPLIT_LIST_INCLUDE = 1
+} ST_SPLIT_LIST_MODE;
+
 typedef struct tag_ST_CONFIGURATION_ENTRY
 {
 	// Offset into buffer region that follows all entries.
@@ -17,10 +26,13 @@ ST_CONFIGURATION_ENTRY;
 
 typedef struct tag_ST_CONFIGURATION_HEADER
 {
-	// Number of entries immediately following the header.
-	SIZE_T NumEntries;
+        // Number of entries immediately following the header.
+        SIZE_T NumEntries;
 
-	// Total byte length: header + entries + string buffer.
-	SIZE_T TotalLength;
+        // Total byte length: header + entries + string buffer.
+        SIZE_T TotalLength;
+
+        // How the image list should be interpreted
+        ST_SPLIT_LIST_MODE Mode;
 }
 ST_CONFIGURATION_HEADER;

--- a/src/driverentry.cpp
+++ b/src/driverentry.cpp
@@ -643,8 +643,9 @@ StEvtIoDeviceControlSerial
             if (IoControlCode == IOCTL_ST_SET_CONFIGURATION)
             {
                 registeredimage::CONTEXT *imageset;
+                ST_SPLIT_LIST_MODE mode;
 
-                auto status = ioctl::SetConfigurationPrepare(Request, &imageset);
+                auto status = ioctl::SetConfigurationPrepare(Request, &imageset, &mode);
 
                 if (!NT_SUCCESS(status))
                 {
@@ -656,7 +657,7 @@ StEvtIoDeviceControlSerial
                 //
                 // Potential state transition here.
                 //
-                status = ioctl::SetConfiguration(device, imageset);
+                status = ioctl::SetConfiguration(device, imageset, mode);
 
                 WdfRequestComplete(Request, status);
 

--- a/src/ioctl.cpp
+++ b/src/ioctl.cpp
@@ -701,7 +701,6 @@ RegisterConfigurationAtReady
 
     Context->RegisteredImage.Instance = Imageset;
     Context->RegisteredImage.Mode = Mode;
-    Context->RegisteredImage.Mode = Mode;
 
     auto status = EnterEngagedState(Context, &Context->IpAddresses);
 
@@ -732,6 +731,7 @@ RegisterConfigurationAtEngaged
     auto oldConfiguration = Context->RegisteredImage.Instance;
 
     Context->RegisteredImage.Instance = Imageset;
+    Context->RegisteredImage.Mode = Mode;
 
     //
     // Update process registry to reflect new configuration.

--- a/src/ioctl.cpp
+++ b/src/ioctl.cpp
@@ -118,7 +118,11 @@ UpdateTargetSplitSetting
 
     Entry->TargetSettings.Split = ST_PROCESS_SPLIT_STATUS_OFF;
 
-    if (registeredimage::HasEntryExact(context->RegisteredImage.Instance, &Entry->ImageName))
+    auto mode = context->RegisteredImage.Mode;
+    const bool inList = registeredimage::HasEntryExact(context->RegisteredImage.Instance, &Entry->ImageName);
+
+    if ((mode == ST_SPLIT_LIST_EXCLUDE && inList) ||
+        (mode == ST_SPLIT_LIST_INCLUDE && !inList))
     {
         Entry->TargetSettings.Split = ST_PROCESS_SPLIT_STATUS_ON_BY_CONFIG;
     }
@@ -669,7 +673,8 @@ NTSTATUS
 RegisterConfigurationAtReady
 (
     ST_DEVICE_CONTEXT *Context,
-    registeredimage::CONTEXT *Imageset
+    registeredimage::CONTEXT *Imageset,
+    ST_SPLIT_LIST_MODE Mode
 )
 {
     //
@@ -681,6 +686,7 @@ RegisterConfigurationAtReady
         auto oldConfiguration = Context->RegisteredImage.Instance;
 
         Context->RegisteredImage.Instance = Imageset;
+        Context->RegisteredImage.Mode = Mode;
 
         registeredimage::TearDown(&oldConfiguration);
 
@@ -694,6 +700,8 @@ RegisterConfigurationAtReady
     auto oldConfiguration = Context->RegisteredImage.Instance;
 
     Context->RegisteredImage.Instance = Imageset;
+    Context->RegisteredImage.Mode = Mode;
+    Context->RegisteredImage.Mode = Mode;
 
     auto status = EnterEngagedState(Context, &Context->IpAddresses);
 
@@ -717,7 +725,8 @@ NTSTATUS
 RegisterConfigurationAtEngaged
 (
     ST_DEVICE_CONTEXT *Context,
-    registeredimage::CONTEXT *Imageset
+    registeredimage::CONTEXT *Imageset,
+    ST_SPLIT_LIST_MODE Mode
 )
 {
     auto oldConfiguration = Context->RegisteredImage.Instance;
@@ -885,6 +894,8 @@ Initialize
         goto Abort_teardown_procbroker;
     }
 
+    context->RegisteredImage.Mode = ST_SPLIT_LIST_EXCLUDE;
+
     status = InitializeProcessRegistryMgmt(&context->ProcessRegistry);
 
     if (!NT_SUCCESS(status))
@@ -970,10 +981,12 @@ NTSTATUS
 SetConfigurationPrepare
 (
     WDFREQUEST Request,
-    registeredimage::CONTEXT **Imageset
+    registeredimage::CONTEXT **Imageset,
+    ST_SPLIT_LIST_MODE *Mode
 )
 {
     *Imageset = NULL;
+    *Mode = ST_SPLIT_LIST_EXCLUDE;
 
     PVOID buffer;
     size_t bufferLength;
@@ -998,6 +1011,8 @@ SetConfigurationPrepare
     auto header = (ST_CONFIGURATION_HEADER*)buffer;
     auto entry = (ST_CONFIGURATION_ENTRY*)(header + 1);
     auto stringBuffer = (UCHAR*)(entry + header->NumEntries);
+
+    *Mode = header->Mode;
 
     if (header->NumEntries == 0)
     {
@@ -1061,7 +1076,8 @@ NTSTATUS
 SetConfiguration
 (
     WDFDEVICE Device,
-    registeredimage::CONTEXT *Imageset
+    registeredimage::CONTEXT *Imageset,
+    ST_SPLIT_LIST_MODE Mode
 )
 {
     auto context = DeviceGetSplitTunnelContext(Device);
@@ -1074,13 +1090,13 @@ SetConfiguration
     {
         case ST_DRIVER_STATE_READY:
         {
-            status = RegisterConfigurationAtReady(context, Imageset);
+            status = RegisterConfigurationAtReady(context, Imageset, Mode);
 
             break;
         }
         case ST_DRIVER_STATE_ENGAGED:
         {
-            status = RegisterConfigurationAtEngaged(context, Imageset);
+            status = RegisterConfigurationAtEngaged(context, Imageset, Mode);
 
             break;
         }
@@ -1214,6 +1230,7 @@ GetConfigurationComplete
 
     header->NumEntries = computeContext.NumEntries;
     header->TotalLength = requiredLength;
+    header->Mode = context->RegisteredImage.Mode;
 
     info = requiredLength;
 

--- a/src/ioctl.h
+++ b/src/ioctl.h
@@ -3,6 +3,7 @@
 #include <ntddk.h>
 #include <wdf.h>
 #include "containers/registeredimage.h"
+#include "defs/config.h"
 
 namespace ioctl
 {

--- a/src/ioctl.h
+++ b/src/ioctl.h
@@ -30,14 +30,16 @@ NTSTATUS
 SetConfigurationPrepare
 (
     WDFREQUEST Request,
-    registeredimage::CONTEXT **Imageset
+    registeredimage::CONTEXT **Imageset,
+    ST_SPLIT_LIST_MODE *Mode
 );
 
 NTSTATUS
 SetConfiguration
 (
     WDFDEVICE Device,
-    registeredimage::CONTEXT *Imageset
+    registeredimage::CONTEXT *Imageset,
+    ST_SPLIT_LIST_MODE Mode
 );
 
 void

--- a/src/procmgmt/procmgmt.cpp
+++ b/src/procmgmt/procmgmt.cpp
@@ -156,8 +156,12 @@ EvaluateSplitting
 )
 {
     auto registeredImage = Context->RegisteredImage->Instance;
+    auto mode = Context->RegisteredImage->Mode;
 
-    if (registeredimage::HasEntryExact(registeredImage, &RegistryEntry->ImageName))
+    const bool inList = registeredimage::HasEntryExact(registeredImage, &RegistryEntry->ImageName);
+
+    if ((mode == ST_SPLIT_LIST_EXCLUDE && inList) ||
+        (mode == ST_SPLIT_LIST_INCLUDE && !inList))
     {
         RegistryEntry->Settings.Split = ST_PROCESS_SPLIT_STATUS_ON_BY_CONFIG;
         ArrivalEvent->SplittingReason |= ST_SPLITTING_REASON_BY_CONFIG;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -26,6 +26,11 @@ ValidateUserBufferConfiguration
         return false;
     }
 
+    if (header->Mode != ST_SPLIT_LIST_EXCLUDE && header->Mode != ST_SPLIT_LIST_INCLUDE)
+    {
+        return false;
+    }
+
     //
     // Verify that the entries reside within the buffer
     //


### PR DESCRIPTION
## Summary
- introduce `ST_SPLIT_LIST_MODE` to choose how app lists are interpreted
- store the mode in driver context
- update IOCTL handlers and driverentry to pass and use the new mode
- allow querying and setting configuration with include mode
- update README to describe new behaviour

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68442db0dbe48333949084109d9c2de5